### PR TITLE
Fetch single food

### DIFF
--- a/routes/api/v1/foods.js
+++ b/routes/api/v1/foods.js
@@ -2,6 +2,28 @@ const express = require('express');
 const router = express.Router();
 const Food = require('../../../models').Food;
 
+router.get('/:id', function(req, res) {
+  Food.findOne(
+    {
+      attributes: ["id", "name", "calories"],
+      where: { id: req.params.id }
+    }
+  )
+  .then(food => {
+    if (food) {
+      res.setHeader("Content-Type", "application/json");
+      res.status(200).send(JSON.stringify(food));
+    } else {
+      res.setHeader("Content-Type", "application/json");
+      res.status(404).send(JSON.stringify({error: "No food with that ID can be found."}));
+    }
+  })
+  .catch(error => {
+    res.setHeader("Content-Type", "application/json");
+    res.status(500).send(JSON.stringify(error));
+  });
+});
+
 router.get('/', function(req, res) {
   Food.findAll({attributes: ["id", "name", "calories"]})
   .then(foods => {

--- a/spec/api/v1/food_fetch.spec.js
+++ b/spec/api/v1/food_fetch.spec.js
@@ -46,5 +46,13 @@ describe('api', () => {
         expect(Object.keys(response.body)).toContain("calories");
       });
     });
+
+    test('It should return an error on invalid id', () => {
+    return request(app).get("/api/v1/foods/10000")
+      .then(response => {
+        expect(response.statusCode).toBe(404);
+        expect(Object.keys(response.body)).toContain("error");
+      });
+    });
   });
 });

--- a/spec/api/v1/food_fetch.spec.js
+++ b/spec/api/v1/food_fetch.spec.js
@@ -29,4 +29,22 @@ describe('api', () => {
       });
     });
   });
+
+  describe('api v1 food fetch single path', () => {
+    test('It should respond to a GET request', () => {
+    return request(app).get("/api/v1/foods/1")
+      .then(response => {
+        expect(response.statusCode).toBe(200);
+      });
+    });
+
+    test('It should return a single food object', () => {
+    return request(app).get("/api/v1/foods/1")
+      .then(response => {
+        expect(Object.keys(response.body)).toContain("id");
+        expect(Object.keys(response.body)).toContain("name");
+        expect(Object.keys(response.body)).toContain("calories");
+      });
+    });
+  });
 });


### PR DESCRIPTION
Adds an endpoint that takes a get request to /api/v1/foods/:id that returns information about a single food item.
Adds testing for the endpoint, including sad path testing if an item is not found in the database.
Completes #6 