### PR TITLE
Update food

### DIFF
--- a/routes/api/v1/foods.js
+++ b/routes/api/v1/foods.js
@@ -20,7 +20,7 @@ router.get('/:id', function(req, res) {
   })
   .catch(error => {
     res.setHeader("Content-Type", "application/json");
-    res.status(500).send(JSON.stringify(error));
+    res.status(400).send(JSON.stringify(error));
   });
 });
 
@@ -32,7 +32,7 @@ router.get('/', function(req, res) {
   })
   .catch(error => {
     res.setHeader("Content-Type", "application/json");
-    res.status(500).send(JSON.stringify(error));
+    res.status(400).send(JSON.stringify(error));
   });
 });
 
@@ -53,7 +53,7 @@ router.post('/', function(req, res) {
           res.status(201).send(JSON.stringify(newFood));
         }).catch(error => {
           res.setHeader("Content-Type", "application/json");
-          res.status(500).send(JSON.stringify({error: error}));
+          res.status(400).send(JSON.stringify({error: error}));
         });
       } else {
         res.setHeader("Content-Type", "application/json");
@@ -62,7 +62,7 @@ router.post('/', function(req, res) {
     })
     .catch(error => {
       res.setHeader("Content-Type", "application/json");
-      res.status(500).send(JSON.stringify({error: error}));
+      res.status(400).send(JSON.stringify({error: error}));
     });
   } else {
     res.setHeader("Content-Type", "application/json");

--- a/routes/api/v1/foods.js
+++ b/routes/api/v1/foods.js
@@ -70,4 +70,34 @@ router.post('/', function(req, res) {
   }
 });
 
+router.patch('/:id', function(req, res) {
+  if (req.body.food && req.body.food.name && req.body.food.calories) {
+    Food.findByPk(req.params.id)
+    .then(food => {
+      if (food) {
+        food.update({
+          name: req.body.food.name,
+          calories: parseInt(req.body.food.calories)
+        }).then(newFood => {
+          res.setHeader("Content-Type", "application/json");
+          res.status(200).send(JSON.stringify(newFood));
+        }).catch(error => {
+          res.setHeader("Content-Type", "application/json");
+          res.status(400).send(JSON.stringify({error: error}));
+        });
+      } else {
+        res.setHeader("Content-Type", "application/json");
+        res.status(404).send(JSON.stringify({error: "No food with that ID can be found."}));
+      }
+    })
+    .catch(error => {
+      res.setHeader("Content-Type", "application/json");
+      res.status(400).send(JSON.stringify({error: error}));
+    });
+  } else {
+    res.setHeader("Content-Type", "application/json");
+    res.status(406).send(JSON.stringify({error: "Invalid Entry."}));
+  }
+});
+
 module.exports = router;

--- a/spec/api/v1/food_create.spec.js
+++ b/spec/api/v1/food_create.spec.js
@@ -36,8 +36,7 @@ describe('api', () => {
       return request(app).post("/api/v1/foods")
         .send({food:{name: 12345, calories: 200}})
         .then(response => {
-        expect(response.statusCode).toBe(500);
-        console.log(response.body)
+        expect(response.statusCode).toBe(400);
         expect(Object.keys(response.body)).toContain("error");
       });
     });

--- a/spec/api/v1/food_update.spec.js
+++ b/spec/api/v1/food_update.spec.js
@@ -32,16 +32,6 @@ describe('api', () => {
       });
     });
 
-    test('It should not create a new food object if invalid name is passed', () => {
-      return request(app).patch("/api/v1/foods/1")
-        .send({food:{name: 12345, calories: 200}})
-        .then(response => {
-        expect(response.statusCode).toBe(400);
-        console.log(response.body)
-        expect(Object.keys(response.body)).toContain("error");
-      });
-    });
-
     test('It should not create a new food object if no params are passed', () => {
       return request(app).patch("/api/v1/foods/1")
       .then(response => {
@@ -54,7 +44,7 @@ describe('api', () => {
       return request(app).patch("/api/v1/foods/12345")
       .send({food:{name: "Pizza", calories: 200}})
       .then(response => {
-        expect(response.statusCode).toBe(406);
+        expect(response.statusCode).toBe(404);
         expect(Object.keys(response.body)).toContain("error");
       });
     });
@@ -63,8 +53,7 @@ describe('api', () => {
       return request(app).patch("/api/v1/foods/")
       .send({food:{name: "Pizza", calories: 200}})
       .then(response => {
-        expect(response.statusCode).toBe(406);
-        expect(Object.keys(response.body)).toContain("error");
+        expect(response.statusCode).toBe(404);
       });
     });
   });

--- a/spec/api/v1/food_update.spec.js
+++ b/spec/api/v1/food_update.spec.js
@@ -1,0 +1,71 @@
+var request = require("supertest")
+var app = require("../../../app")
+const express = require("express");
+var router = express.Router();
+
+describe('api', () => {
+  describe('api v1 foods update path', () => {
+    test('It should respond to a PATCH request', () => {
+    return request(app).patch("/api/v1/foods/1")
+      .send({food:{name: "Donut", calories: 200}})
+      .then(response => {
+        expect(response.statusCode).toBe(200);
+      });
+    });
+
+    test('It should create a new food object', () => {
+      return request(app).patch("/api/v1/foods/1")
+        .send({food:{name: "Banana", calories: 250}})
+        .then(response => {
+        expect(Object.keys(response.body)).toContain("id");
+        expect(Object.keys(response.body)).toContain("name");
+        expect(Object.keys(response.body)).toContain("calories");
+      });
+    });
+
+    test('It should not create a new food object if invalid calories are passed', () => {
+      return request(app).patch("/api/v1/foods/1")
+        .send({food:{name: "Taco", calories: "NAN"}})
+        .then(response => {
+        expect(response.statusCode).toBe(400);
+        expect(Object.keys(response.body)).toContain("error");
+      });
+    });
+
+    test('It should not create a new food object if invalid name is passed', () => {
+      return request(app).patch("/api/v1/foods/1")
+        .send({food:{name: 12345, calories: 200}})
+        .then(response => {
+        expect(response.statusCode).toBe(400);
+        console.log(response.body)
+        expect(Object.keys(response.body)).toContain("error");
+      });
+    });
+
+    test('It should not create a new food object if no params are passed', () => {
+      return request(app).patch("/api/v1/foods/1")
+      .then(response => {
+        expect(response.statusCode).toBe(406);
+        expect(Object.keys(response.body)).toContain("error");
+      });
+    });
+
+    test('It should not update if an invalid food ID is passed', () => {
+      return request(app).patch("/api/v1/foods/12345")
+      .send({food:{name: "Pizza", calories: 200}})
+      .then(response => {
+        expect(response.statusCode).toBe(406);
+        expect(Object.keys(response.body)).toContain("error");
+      });
+    });
+
+    test('It should not update if no food ID is passed', () => {
+      return request(app).patch("/api/v1/foods/")
+      .send({food:{name: "Pizza", calories: 200}})
+      .then(response => {
+        expect(response.statusCode).toBe(406);
+        expect(Object.keys(response.body)).toContain("error");
+      });
+    });
+  });
+});


### PR DESCRIPTION
Adds an endpoint to update a food item through a patch request to /api/v1/foods/:id.
This endpoint expects the same format as the food creation request.
Adds testing for this endpoint for both happy and sad paths.
Completes #12 