### PR TITLE
Delete food

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "start": "node ./bin/www",
-    "test": "jest --forceExit"
+    "test": "jest --runInBand --forceExit"
   },
   "dependencies": {
     "cookie-parser": "~1.4.4",

--- a/routes/api/v1/foods.js
+++ b/routes/api/v1/foods.js
@@ -100,4 +100,27 @@ router.patch('/:id', function(req, res) {
   }
 });
 
+router.delete('/:id', function(req, res) {
+  Food.findByPk(req.params.id)
+  .then(food => {
+    if (food) {
+      food.destroy()
+      .then(() => {
+        res.setHeader("Content-Type", "application/json");
+        res.status(204).send();
+      }).catch(error => {
+        res.setHeader("Content-Type", "application/json");
+        res.status(400).send(JSON.stringify({error: error}));
+      });
+    } else {
+      res.setHeader("Content-Type", "application/json");
+      res.status(404).send(JSON.stringify({error: "No food with that ID can be found."}));
+    }
+  })
+  .catch(error => {
+    res.setHeader("Content-Type", "application/json");
+    res.status(400).send(JSON.stringify({error: error}));
+  });
+});
+
 module.exports = router;

--- a/spec/api/v1/food_delete.spec.js
+++ b/spec/api/v1/food_delete.spec.js
@@ -1,0 +1,49 @@
+var request = require("supertest")
+var app = require("../../../app")
+const express = require("express");
+var router = express.Router();
+
+describe('api', () => {
+  describe('api v1 foods delete path', () => {
+    test('It should respond to a DELETE request', () => {
+    return request(app).delete("/api/v1/foods/3")
+      .send()
+      .then(response => {
+        expect(response.statusCode).toBe(204);
+      });
+    });
+
+    test('It should delete a food object', () => {
+      return request(app).get("/api/v1/foods")
+        .send()
+        .then(response => {
+        initalLength = response.body.length;
+        request(app).delete("/api/v1/foods/4")
+        .send()
+        .then(() => {
+          request(app).get("/api/v1/foods")
+          .send()
+          .then(response => {
+          expect(response.body.length).toBe(initalLength-1);
+          })
+        })
+      });
+    });
+
+    test('It should not delete a food object if an invalid ID is passed', () => {
+      return request(app).delete("/api/v1/foods/12345")
+        .send()
+        .then(response => {
+        expect(response.statusCode).toBe(404);
+        expect(Object.keys(response.body)).toContain("error");
+      });
+    });
+
+    test('It should not delete a food object if no params are passed', () => {
+      return request(app).delete("/api/v1/foods")
+      .then(response => {
+        expect(response.statusCode).toBe(404);
+      });
+    });
+  });
+});

--- a/spec/api/v1/food_fetch.spec.js
+++ b/spec/api/v1/food_fetch.spec.js
@@ -18,9 +18,9 @@ describe('api', () => {
         expect(Object.keys(response.body[0])).toContain("id");
         expect(Object.keys(response.body[0])).toContain("name");
         expect(Object.keys(response.body[0])).toContain("calories");
-        expect(Object.keys(response.body[6])).toContain("id");
-        expect(Object.keys(response.body[6])).toContain("name");
-        expect(Object.keys(response.body[6])).toContain("calories");
+        expect(Object.keys(response.body[1])).toContain("id");
+        expect(Object.keys(response.body[1])).toContain("name");
+        expect(Object.keys(response.body[1])).toContain("calories");
       });
     });
   });


### PR DESCRIPTION
Adds an endpoint to delete a food from the database by sending a delete request to /api/v1/foods/id.
Adds testing for the endpoint, including sad path testing.
Adds small test optimizations.
Completes #13 